### PR TITLE
Bug fixes in login, styles, layout

### DIFF
--- a/event_view.php
+++ b/event_view.php
@@ -12,9 +12,9 @@ $groups = getGroupsByEventIdYear($event_id, $year);
 ?>
 
 
-<link rel="stylesheet" href="styles/groups.css">
 <?php
 $page_title = "View Event";
+$page_styles = ["styles/groups.css"];
 include 'templates/main_header.php'
 ?>
 

--- a/group_create.php
+++ b/group_create.php
@@ -4,7 +4,6 @@ require_once 'includes/db.php';
 
 ensureLoggedIn();
 
-$user = getUserById($_SESSION['user_id']);
 $event_id = $_GET['event_id'];
 $year = $_GET['year'];
 $event = getEventById($event_id);
@@ -58,9 +57,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 ?>
 
 
-<link rel="stylesheet" href="styles/groups.css">
 <?php
 $page_title = "Create Group";
+$page_styles = ["styles/groups.css"];
 include 'templates/main_header.php'
 ?>
 

--- a/group_view.php
+++ b/group_view.php
@@ -12,9 +12,9 @@ $group = getGroupById($_GET['group_id']);
 ?>
 
 
-<link rel="stylesheet" href="styles/groups.css">
 <?php
 $page_title = "View Group";
+$page_styles = ["styles/groups.css"];
 include 'templates/main_header.php'
 ?>
 

--- a/includes/db.php
+++ b/includes/db.php
@@ -61,13 +61,6 @@ function getUserById($userId) {
 
   $user = $stmt->fetch();
 
-  // check if user is missing in db, but session cache still has a user_id set
-  if ($user === false) {
-    session_unset();
-    header('Location: /login.php');
-    exit;
-  }
-
   return $user;
 }
 

--- a/includes/session.php
+++ b/includes/session.php
@@ -1,29 +1,33 @@
 <?php
+require_once "db.php";
 
 function startSession() {
   if (!isset($_SESSION)) session_start();
 }
 
 function getUserId() {
-  startSession();
-  if (isset($_SESSION['user_id'])) {
-    return $_SESSION['user_id'];
-  } else {
-    return null;
+  global $user;
+
+  if (!$user) {
+    startSession();
+    $user = getUserById($_SESSION['user_id'] ?? null);
+    if (!$user) {
+      return null;
+    }
   }
+
+  return $user["id"];
 }
 
 function ensureLoggedIn() {
-  startSession();
-  if (!isset($_SESSION['user_id'])) {
+  if (!getUserId()) {
     header('Location: ./login.php');
     exit;
   }
 }
 
 function ensureLoggedOut() {
-  startSession();
-  if (isset($_SESSION['user_id'])) {
+  if (getUserId()) {
     header('Location: ./');
     exit;
   }

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+session_unset();
 session_destroy();
 header('Location: ./');
 exit;

--- a/profile.php
+++ b/profile.php
@@ -3,8 +3,6 @@ require_once 'includes/session.php';
 require_once 'includes/db.php';
 
 ensureLoggedIn();
-
-$user = getUserById(getUserId())
 ?>
 
 <?php

--- a/styles/groups.css
+++ b/styles/groups.css
@@ -31,16 +31,11 @@ ul.group-list li div {
 }
 
 .content.create-group textarea {
-  display: flex;
-  justify-content: center;
   width: 80%;
   min-height: 100px;
   max-height: 150px;
-  border: 1px solid var(--color-accent);
-  border-radius: 0.5em;
   margin: 4px;
   resize: vertical;
-  font-size: 16px;
 }
 
 .form-checkbox-wrapper {

--- a/styles/main.css
+++ b/styles/main.css
@@ -14,9 +14,6 @@
 }
 
 body {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
   font-family: sans-serif;
   color: var(--color-text);
   background-color: var(--color-background-body);
@@ -47,15 +44,18 @@ form {
 }
 
 form input,
-form button {
+form button,
+form textarea {
   width: 100%;
 }
 
 input,
 button,
+textarea,
 a.btn {
   display: block;
   font-size: inherit;
+  font-family: inherit;
   border: 1px solid var(--color-accent);
   padding: 1em;
   margin: 1em 0;
@@ -82,6 +82,7 @@ p.error {
 .wrapper {
   width: 100%;
   max-width: 1000px;
+  margin: 0 auto;
 }
 
 nav {
@@ -92,6 +93,7 @@ nav {
   left: 0;
   color: var(--color-text-accent);
   background-color: var(--color-accent);
+  z-index: 1;
 }
 
 nav h1 {
@@ -191,6 +193,7 @@ ul.event-list li {
 
   body {
     flex-direction: unset;
+    padding-top: var(--nav-height);
   }
 
   nav {
@@ -223,8 +226,9 @@ ul.event-list li {
     width: unset;
   }
 
-  .content {
-    margin-top: calc(1em + var(--nav-height));
+  .content.login {
+    margin-top: calc(50vh - var(--nav-height));
+    transform: translateY(-50%);
   }
 
 }

--- a/templates/main_header.php
+++ b/templates/main_header.php
@@ -1,6 +1,5 @@
 <?php
 require_once 'includes/gravatar.php';
-$user = getUserById(getUserId());
 
 function active($param) {
   $isActive = basename($_SERVER['SCRIPT_NAME'], ".php") === $param;
@@ -15,6 +14,11 @@ function active($param) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/x-icon" href="<?php echo gravatarUrl('Events System') ?>">
   <link rel="stylesheet" href="styles/main.css">
+  <?php if (isset($page_styles)): ?>
+  <?php foreach ($page_styles as $style): ?>
+    <link rel="stylesheet" href="<?php echo $style?>">
+  <?php endforeach ?>
+  <?php endif ?>
   <title><?php echo $page_title." | Events System" ?></title>
 </head>
 <body>
@@ -25,7 +29,7 @@ function active($param) {
           <span><h1>Events System</h1></span>
         </li>
       </ul>
-      <?php if ($user): ?>
+      <?php if (isset($user) && $user): ?>
       <ul class="middle">
         <li>
           <a href="./" <?php active("index") ?>>Events</a>


### PR DESCRIPTION
* По бъга който @RadoslavBotov откри:
  * преместих фикса да се случва при `ensureLoggedIn` и `ensureLoggdedOut`, защото `getUserById` е обща функция към базата която може да се използва извън сесията.
  * `./login.php` != `/login.php` при мен сайта е на `localhost/eventsys/` например и ме пращаше в грешка 404
  * като последствие всяка страница на която е извикана `ensureLoggedIn` получава безплатно текущия `$user`
* Забелязах че заради CSS-a на navbar-a част от PHP грешките остават скрити. Промених го така че да се виждат всички.
* Както @RadoslavBotov спомена заради тези `<link>` преди `<head>` цялото съдържание на `<head>` се рендерираше в `<body>` - добавих променлива за стилове специфични за страницата.
* Извадих общия css между input, button и textarea в `main.css`
