### PR TITLE
group member page for non admins to see members

### DIFF
--- a/event_create.php
+++ b/event_create.php
@@ -56,12 +56,12 @@ include 'templates/main_header.php'
   <section class="content create-event">
     <form method="POST">
       <label>
-        Name:
+        Name: <b class="red">*</b>
         <input type="text" name="name" placeholder="<?php echo $user['username']?>'s event" required>
       </label>
 
       <label>
-        Date:
+        Date: <b class="red">*</b>
         <input type="date" name="date" value="" required>
       </label>
 

--- a/group_members.php
+++ b/group_members.php
@@ -1,0 +1,71 @@
+<?php
+require_once 'includes/session.php';
+require_once 'includes/db_events.php';
+require_once 'includes/db_groups.php';
+
+ensureLoggedIn();
+
+$year = $_GET['year'];
+$user_id = $user['id'];
+$group_id = $_GET['group_id'];
+$event_id = $_GET['event_id'];
+
+if (checkGroupHiddenFromUser($user_id, $event_id, $group_id)) {
+  header('Location: event_view.php?event_id=' . $event_id . '&year=' . $_GET['year']);
+  exit;
+}
+
+$in_group = checkUserInGroup($user_id, $event_id, $group_id);
+
+?>
+
+
+<?php
+$page_title = 'View Group';
+$page_styles = ['styles/groups.css'];
+include 'templates/main_header.php';
+include 'templates/data_table.php';
+?>
+
+<section class="content">
+  <a class="btn" href="group_view.php?event_id=<?php echo $event_id; ?>&group_id=<?php echo $group_id; ?>&year=<?php echo $year; ?>">&lt Go back</a>
+  <?php
+  data_table(
+    function ($limit, $offset) {
+      global $group_id;
+      return getUsersInGroup($group_id, $limit, $offset, true);
+    },
+    function () {
+      global $group_id;
+      return getUsersInGroupCount($group_id);
+    },
+    10,
+    [
+      'User' => function ($row) { ?>
+    <div class="profile-info">
+      <img class="profile-picture" alt="Profile Picture" src="<?php echo gravatarUrl($row) ?>"></img>
+      <a href="<?php echo 'user.php?id=' . $row['user_id'] ?>"><?php echo $row['username'] ?></a>
+    </div>
+    <?php
+      },
+      'Status' => function ($row) {
+        switch ($row['user_status']) {
+          case 0:
+            echo '<span class="green">Admin</span>';
+            break;
+          case 1:
+            echo 'Member';
+            break;
+          case 2:
+            echo '<span class="red">Hidden</span>';
+            break;
+        }
+      }
+    ]
+  ) ?>
+</section>
+
+
+<?php
+include 'templates/main_footer.php'
+?>

--- a/group_view.php
+++ b/group_view.php
@@ -92,6 +92,7 @@ include 'templates/main_header.php'
     <h2><?php echo $group['group_name']; ?></h2>
   </header>
   <?php if ($in_group): ?>  <!-- User in group => can show content -->
+    <a href="group_members.php?event_id=<?php echo $event_id; ?>&group_id=<?php echo $group_id; ?>&year=<?php echo $year; ?>"><?php echo getUsersInGroupCount($group_id); ?> members</a>
     <header>
       <h2>...Chat...</h2>
     </header>

--- a/includes/db_groups.php
+++ b/includes/db_groups.php
@@ -242,10 +242,10 @@ function getUsersInGroupCount($group_id) {
 }
 
 function getUsersNotInGroup($group_id, $viewer, $query, $limit, $offset) {
-  // TODO: exclude users who cannot see Event, so that group admin can't add them to group
   $pdo = getPDO();
 
   // select users not in group and users group is not hidden from
+  // exclude users that cannot see event, which group is attached to
   $stmt = $pdo->prepare("SELECT u.id,
                                        u.username,
                                        u.email,
@@ -257,7 +257,8 @@ function getUsersNotInGroup($group_id, $viewer, $query, $limit, $offset) {
                                       SELECT *
                                       FROM user_hidden_group) as gr ON u.id = gr.user_id AND gr.group_id = ?
                             LEFT JOIN favorite_users fu ON fu.user_id = ? AND fu.favorite_user_id = u.id
-                        WHERE u.username LIKE CONCAT('%', ?, '%') AND gr.group_id IS NULL
+                            LEFT JOIN user_hidden_event uhe ON uhe.user_id = u.id
+                        WHERE u.username LIKE CONCAT('%', ?, '%') AND gr.group_id IS NULL AND uhe.user_id IS NULL
                         ORDER BY fu.favorite_user_id DESC, username
                         LIMIT ? OFFSET ?");
   $stmt->execute([$group_id, $viewer, $query, $limit, $offset]);

--- a/styles/groups.css
+++ b/styles/groups.css
@@ -50,6 +50,10 @@ ul.group-list li {
   text-decoration: underline;
 }
 
+.data-table.group_members .profile-picture {
+  width: 2.5em;
+}
+
 .data-table.group_edit .btn {
   max-width: 200px;
   margin: 4px;


### PR DESCRIPTION
- added a page for non admin members of group to see other users in same group
- updated getUsersNotInGroup() to exclude users that cannot see the event to which the group is attached to, as to prevent admin from adding them to the group and bypass the hidden condition