### PR TITLE
Group chat and polls and etc.

### DIFF
--- a/api/group_messages.php
+++ b/api/group_messages.php
@@ -1,0 +1,42 @@
+<?php
+require_once '../includes/config.php';
+require_once '../includes/session.php';
+require_once '../includes/db_messages.php';
+
+ensureLoggedIn();
+
+header("Content-Type: application/json");
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $res = storeMessage($user['id'], $_POST['group_id'], $_POST['content']);
+
+  echo json_encode($res);
+  exit;
+}
+
+// Release the session lock in this connection before blocking,
+// so that other requests can be processed at the same time.
+session_write_close();
+
+function no_messages($messages) {
+  global $config;
+  if (empty($messages)) {
+    usleep($config['polling_interval'] * 1_000_000);
+    return true;
+  }
+  return false;
+}
+
+function has_time($elapsed) {
+  global $config;
+  return $elapsed < $config['polling_limit'];
+}
+
+$start = time();
+$messages = [];
+do {
+  $messages = getMessages($user['id'], $_GET['group_id'], $_GET['time_after'] ?? '1-1-1');
+} while (no_messages($messages) && has_time(time() - $start));
+
+echo json_encode($messages);
+?>

--- a/event_create.php
+++ b/event_create.php
@@ -37,7 +37,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!empty($result)) {
       $event_id= $result;
 
-      header('Location: event_view.php?event_id=' . $event_id . '&year=' . date('Y', strtotime(($date))));
+      header("Location: event_view.php?event_id=$event_id&year=".date('Y', strtotime(($date))));
       exit;
     }
   }

--- a/event_view.php
+++ b/event_view.php
@@ -8,6 +8,11 @@ ensureLoggedIn();
 $event_id = $_GET['event_id'];
 $year = $_GET['year'];
 $event = getEventById($event_id);
+if (!$event || !$year) {
+  header("Location: ./");
+  exit;
+}
+
 $correct_date = strtotime(date('d M ', strtotime($event['date'])) . $year);
 $groups = getGroupsByEventIdYear($user['id'], $event_id, $year);
 
@@ -15,28 +20,30 @@ $viewer_admin = $event['creator_id'] == $user['id'];
 
 $hidden_select = getHiddenSelect($event_id);
 
-if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['delete_event'])) {
-  if (!$viewer_admin) {
-    $error_message = "You do not have permission to delete this event.";
-  } else {
-    deleteEventById($event_id);
-    header("Location: index.php");
-    exit();
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+  if (isset($_POST['delete_event'])) {
+    if (!$viewer_admin) {
+      $error_message = "You do not have permission to delete this event.";
+    } else {
+      deleteEventById($event_id);
+      header("Location: ./");
+      exit;
+    }
   }
-}
 
-if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['modify_event'])) {
-  if (!$viewer_admin) {
-    $error_message = "You do not have permission to modify this event.";
-  } else {
-    $modified_name = $_POST['event_name'];
-    $modified_date = $_POST['event_date'];
-    $modified_description = $_POST['event_description'];
-    
-    $users_to_hide = $_POST['users_to_hide'] ?? [];
-    modifyEvent($event_id, $modified_name, $modified_date, $modified_description, $users_to_hide);
-    header("Location: event_view.php?event_id=$event_id&year=$year");
-    exit();
+  if (isset($_POST['modify_event'])) {
+    if (!$viewer_admin) {
+      $error_message = "You do not have permission to modify this event.";
+    } else {
+      $modified_name = $_POST['event_name'];
+      $modified_date = $_POST['event_date'];
+      $modified_description = $_POST['event_description'];
+      
+      $users_to_hide = $_POST['users_to_hide'] ?? [];
+      modifyEvent($event_id, $modified_name, $modified_date, $modified_description, $users_to_hide);
+      header("Location: ".$_SERVER['REQUEST_URI']);
+      exit;
+    }
   }
 }
 ?>
@@ -44,29 +51,34 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['modify_event'])) {
 <?php
 $page_title = "View Event";
 $page_styles = ["styles/groups.css"];
+$page_scripts = ["javascript/event_view.js"];
 include 'templates/select_dynamic.php';
 include 'templates/main_header.php';
 ?>
 
 <section class="content">
-  <header>
-    <h1>View Event</h1>
+  <header class="space-betwen">
+    <div>
+      <h2><?php echo htmlspecialchars($event['name']) ?> | <?php echo date('d F Y, l', $correct_date) ?></h2>
+      <?php if ($event['creator_id']): ?>
+        Created by <a href="user.php?id=<?php echo $event['creator_id'] ?>"><?php echo $event['creator_username'] ?></a>
+      <?php endif ?>
+    </div>
+    <?php if ($viewer_admin): ?>
+    <div>
+      <button type="button" class="btn" id="modifyButton" onclick="toggleModifyForm()">Modify Event</button>
+      <button type="button" class="btn delete" id="deleteButton" onclick="toggleDeleteModal()">Delete Event</button>
+    </div>
+    <?php endif; ?>
   </header>
 
-  <h3><?php echo $event['name']; ?> | <?php echo date('d F Y, l', $correct_date) ?></h3>
-  <?php if ($event['creator_id']): ?>
-    Created by <a href="user.php?id=<?php echo $event['creator_id'] ?>"><?php echo $event['creator_username'] ?></a>
-  <?php endif ?>
-
-  <p><?php echo $event['description'];?></p>
+  <p><?php echo htmlspecialchars($event['description']);?></p>
 
   <?php if (isset($error_message)): ?>
     <div style="color: red; font-weight: bold;"><?php echo $error_message; ?></div>
   <?php endif; ?>
 
   <?php if ($viewer_admin): ?>
-    <button type="button" class="btn" id="modifyButton" onclick="toggleModifyForm()">Modify Event</button>
-
     <form method="POST" id="modifyForm" style="display:none;">
       <label for="event_name">Event Name:</label>
       <input type="text" name="event_name" id="event_name" value="<?php echo htmlspecialchars($event['name']); ?>" required>
@@ -84,10 +96,6 @@ include 'templates/main_header.php';
       <button type="submit" class="btn" name="modify_event">Save Changes</button>
       <button type="button" class="btn" onclick="toggleModifyForm()">Cancel</button>
     </form>
-  <?php endif; ?>
-
-  <?php if ($viewer_admin): ?>
-    <button type="button" class="btn delete" id="deleteButton" onclick="confirmDelete()">Delete Event</button>
 
     <div id="deleteModal" style="display:none;">
       <p>Are you sure you want to delete this event?</p>
@@ -98,7 +106,7 @@ include 'templates/main_header.php';
     </div>
   <?php endif; ?>
 
-  <header>
+  <header class="space-betwen">
     <h2>Groups</h2>
     <a class="btn" href="group_create.php?event_id=<?php echo $event_id?>&year=<?php echo $year ?>">Create Group</a>
   </header>
@@ -113,12 +121,12 @@ include 'templates/main_header.php';
           <h3>
           <?php
           if ($group['group_pass']) {
-            echo '&#x1F512 ';
+            echo '🔒 ';
           }
           echo $group['group_name']
           ?>
           </h3>
-          <p><a href="group_view.php?event_id=<?php echo $event_id ?>&group_id=<?php echo $group['group_id'] ?>&year=<?php echo $year ?>">View</a></p>
+          <p><a href="group_view.php?group_id=<?php echo $group['group_id'] ?>">View</a></p>
         </div>
         <div class="two-items between">
           <p>Money goal: <?php echo $group['money_goal'] ?></p>
@@ -141,22 +149,6 @@ include 'templates/main_header.php';
     <p>No groups created. Be the first!</p>
   <?php endif; ?>
 </section>
-
-<script>
-function toggleModifyForm() {
-  const form = document.getElementById('modifyForm');
-  form.style.display = form.style.display === 'none' ? 'block' : 'none';
-}
-
-function toggleDeleteModal() {
-  const modal = document.getElementById('deleteModal');
-  modal.style.display = modal.style.display === 'none' ? 'block' : 'none';
-}
-
-function confirmDelete() {
-  toggleDeleteModal();
-}
-</script>
 
 <?php
 include 'templates/main_footer.php'

--- a/group_create.php
+++ b/group_create.php
@@ -8,6 +8,10 @@ ensureLoggedIn();
 $event_id = $_GET['event_id'];
 $year = $_GET['year'];
 $event = getEventById($event_id);
+if (!$event || !$year) {
+  header("Location: ./");
+  exit;
+}
 $correct_date = strtotime(date('d M ', strtotime($event['date'])).$year);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -53,7 +57,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       attachGroupToEvent($group_id, $event_id, $year);
       addUserInGroup($user_id, $group_id);
 
-      header('Location: group_view.php?event_id=' . $event_id . '&group_id=' . $group_id . '&year=' . $year);
+      header("Location: group_view.php?group_id=$group_id");
       exit;
     }
   }
@@ -72,7 +76,7 @@ include 'templates/main_header.php'
 <section class="content">
   <a class="btn" href="event_view.php?event_id=<?php echo $event_id ?>&year=<?php echo $year ?>"
   >&lt Go back</a>
-  <h1><?php echo $event['name']?> | <?php echo date('d F Y, l', $correct_date) ?></h1>
+  <h1><?php echo htmlspecialchars($event['name']) ?> | <?php echo date('d F Y, l', $correct_date) ?></h1>
   <h2>Create Group</h2>
   <section class="content group-form">
     <form class="form-group" method="POST">

--- a/group_members.php
+++ b/group_members.php
@@ -5,13 +5,19 @@ require_once 'includes/db_groups.php';
 
 ensureLoggedIn();
 
-$year = $_GET['year'];
-$user_id = $user['id'];
 $group_id = $_GET['group_id'];
-$event_id = $_GET['event_id'];
+$group = getGroupById($group_id);
+if (!$group) {
+  header("Location: ./");
+  exit;
+}
+
+$user_id = $user['id'];
+$event_id = $group['event_id'];
+$year = $group['year'];
 
 if (checkGroupHiddenFromUser($user_id, $event_id, $group_id)) {
-  header('Location: event_view.php?event_id=' . $event_id . '&year=' . $_GET['year']);
+  header("Location: event_view.php?event_id=$event_id&year=$year");
   exit;
 }
 
@@ -28,7 +34,7 @@ include 'templates/data_table.php';
 ?>
 
 <section class="content">
-  <a class="btn" href="group_view.php?event_id=<?php echo $event_id; ?>&group_id=<?php echo $group_id; ?>&year=<?php echo $year; ?>">&lt Go back</a>
+  <a class="btn" href="group_view.php?group_id=<?php echo $group_id; ?>">&lt Go back</a>
   <?php
   data_table(
     function ($limit, $offset) {

--- a/group_view.php
+++ b/group_view.php
@@ -2,104 +2,127 @@
 require_once 'includes/session.php';
 require_once 'includes/db_events.php';
 require_once 'includes/db_groups.php';
+require_once 'includes/db_polls.php';
 
 ensureLoggedIn();
 
-$year = $_GET['year'];
-$user_id = $user['id'];
 $group_id = $_GET['group_id'];
-$event_id = $_GET['event_id'];
-$event = getEventById($event_id);
 $group = getGroupById($group_id);
-$group_pass = $group['group_pass'];
-
-if (checkGroupHiddenFromUser($user_id, $event_id, $group_id)) {
-  header('Location: event_view.php?event_id=' . $event_id . '&year=' . $_GET['year']);
+if (!$group) {
+  header("Location: ./");
   exit;
 }
 
-$in_group = checkUserInGroup($user_id, $event_id, $group_id);
+$user_id = $user['id'];
+$year = $group['year'];
+$event_id = $group['event_id'];
+$event = getEventById($event_id);
+$group_pass = $group['group_pass'];
+$is_private = !!$group['group_pass'];
+
+if (checkGroupHiddenFromUser($user_id, $event_id, $group_id)) {
+  header("Location: event_view.php?event_id=$event_id&year=$year");
+  exit;
+}
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (isset($_POST['form-join'])) { // join group
-
-    if ($group_pass) { // if group is private
-      if ($group_pass === $_POST['group-pass']) { // user provided password is correct
-        addUserInGroup($user_id, $group_id);
-        $in_group = true;
-      } else { // user provided password is NOT correct
-        $error_messages = ['Group pass is incorrect. Please try again.'];
-        $in_group = false;
-      }
-    } else { // if group is public
+    if ($group_pass && $group_pass !== $_POST['group-pass']) { // private and password is incorrect
+      $error_messages = ['Group pass is incorrect. Please try again.'];
+    } else { // public or correct passsword
       addUserInGroup($user_id, $group_id);
-      $in_group = true;
+      header('Location: '.$_SERVER['REQUEST_URI']);
+      exit;
     }
   }
 
   if (isset($_POST['form-leave'])) { // leave group
-    removeUserFromGroup($user_id, $group_id);
-    $in_group = false;
-
-    $users_in_group = getUsersInGroup($group_id); // get all users in group, excluding hidden
-
-    // if there is at least one other users in group after admin leaves
-    if (count($users_in_group) > 0) { // chose a random user for new admin
-      $rand_key = array_rand($users_in_group);
-
-      updateGroup(
-        $group_id,
-        $users_in_group[$rand_key]['user_id'],
-        $group['group_name'],
-        $group['money_goal'],
-        $group['meeting_time'],
-        $group['meeting_place'],
-        $group['group_description'],
-        $group['group_pass']
-      );
-    } else { // otherwise, delete group
-      deleteGroup($group_id, $user_id);
-      header('Location: event_view.php?event_id=' . $event_id . '&year=' . $year);
-      exit;
+    if (leaveGroup($user_id, $group_id)) { // group still exists
+      header('Location: '.$_SERVER['REQUEST_URI']);
+    } else { // group deleted
+      header("Location: event_view.php?event_id=$event_id&year=$year");
     }
+    exit;
   }
 }
+
+$in_group = checkUserInGroup($user_id, $event_id, $group_id);
+$polls = getGroupPolls($group_id);
 ?>
 
 
 <?php
 $page_title = 'View Group';
 $page_styles = ['styles/groups.css'];
+$page_scripts = ["javascript/tabs.js", 'javascript/chat.js', 'javascript/polls.js', 'javascript/group_view.js'];
 include 'templates/main_header.php'
 ?>
 
 <section class="content">
-  <div class="two-items between">
-    <a class="btn" href="event_view.php?event_id=<?php echo $event_id ?>&year=<?php echo $year ?>">&lt Go back</a>
+  <header class="space-betwen">
+    <a class="btn" href="event_view.php?event_id=<?php echo $event_id ?>&year=<?php echo $year ?>">&lt; Backt to Event</a>
+    <h1><?php echo htmlspecialchars($event['name'].' / '.$group['group_name']) ?></h1>
     <?php if ($in_group): ?>
     <div>
       <form id="form-leave-group" method="POST">
         <button type="submit" name="form-leave" class="btn delete">Leave Group</button>
       </form>
       <?php if ($user_id === $group['creator_id']): ?>
-        <a class="btn" href="group_edit.php?event_id=<?php echo $event_id ?>&group_id=<?php echo $group_id ?>&year=<?php echo $year ?>">Edit Group</a>
+        <a class="btn" href="group_edit.php?group_id=<?php echo $group_id ?>">Edit Group</a>
       <?php endif ?>
     </div>
     <?php endif ?>
-  </div>
-  <header>
-    <h1><?php echo $event['name'] ?></h1>
-    <h2><?php echo $group['group_name']; ?></h2>
   </header>
-  <?php if ($in_group): ?>  <!-- User in group => can show content -->
-    <a href="group_members.php?event_id=<?php echo $event_id; ?>&group_id=<?php echo $group_id; ?>&year=<?php echo $year; ?>"><?php echo getUsersInGroupCount($group_id); ?> members</a>
-    <header>
-      <h2>...Chat...</h2>
-    </header>
-  <?php else: ?>  <!-- User NOT in group => JOIN before show content-->
+  <?php if ($in_group): // User in group => can show content ?>
+
+    <ul>
+      <li><b>💸 Money Goal:</b> <?php echo $group['money_goal'] != 0 ? $group['money_goal'] : 'Not set' ?></li>
+      <li><b>📍 Location:</b> <?php echo htmlspecialchars($group['meeting_place'] ?? 'Not set') ?></li>
+      <li><b>⏰ Time:</b> <?php echo htmlspecialchars($group['meeting_time'] ?? 'Not set') ?></li>
+      <li>
+        <?php echo ($is_private ? "🔒 Private" : "🌐 Public")." Group" ?> |
+        <a href="group_members.php?group_id=<?php echo $group_id; ?>"><?php echo getUsersInGroupCount($group_id); ?> members</a>
+      </li>
+    </ul>
+
+    <p><?php echo htmlspecialchars($group['group_description']) ?></p>
+
+    <ul class="group-tabs">
+      <li id="chat-toggle">Chat</li>
+      <li id="polls-toggle">Polls</li>
+    </ul>
+
+    <section id="chat-panel" class="chat" style="display: none">
+      <section id="chat-history" class="chat-history"></section>
+      <form action="api/group_messages.php" id="chat-form" class="chat-form">
+        <input type="hidden" name="group_id" value="<?php echo $group_id ?>">
+        <textarea name="content" placeholder="Aa" autofocus></textarea>
+        <button type="submit">➤</button>
+      </form>
+    </section>
+
+    <section id="polls-panel" class="polls" style="display: none">
+      <section class="polls-container">
+        <?php include 'templates/polls_template.php' ?>
+        <form method="POST" action="poll.php" class="poll-form create">
+          <input type="hidden" name="group_id" value="<?php echo $group_id ?>">
+          <input type="hidden" name="poll_create">
+          <label>
+            <div class="row">
+              <input type="text" name="poll_title" placeholder="Poll Title" required>
+            </div>
+          </label>
+          <div class="row">
+            <button class="btn" type="submit">Create Poll</button>
+          </div>
+        </form>
+      </section>
+    </section>
+
+    <?php else: // User NOT in group => JOIN before show content ?>
   <section class="content group-form">
     <form method="POST">
-    <?php if ($group_pass): ?> <!-- Group is PRIVATE => need GROUP PASS -->
+    <?php if ($group_pass): // Group is PRIVATE => need GROUP PASS ?>
       <h2>Group is private. You need its <span class="hover-pop-up" title="8 character long password. Ask group creator for it.">GROUP PASS</span> to join.</h2>
       <input id="input-group-pass" type="text" maxlength="8" name="group-pass" placeholder="Group pass" required>
     <?php else: ?>

--- a/includes/config.php
+++ b/includes/config.php
@@ -6,6 +6,8 @@ $config = [
   'db_pass' => $_ENV["DB_PASS"] ?? '',
   'db_name' => 'eventsys',
 
+  'polling_limit' => 0.8 * (function_exists('ini_get') ? (int)ini_get('max_execution_time') : 30),
+  'polling_interval' => 1,
   'username_pattern' => '[a-zA-Z0-9]{3,50}',
   'group_pass_characters' => '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
 ];

--- a/includes/db_messages.php
+++ b/includes/db_messages.php
@@ -1,0 +1,42 @@
+<?php
+require_once "db.php";
+
+// Queries
+
+function getMessages($viewer, $group_id, $time_after) {
+  $pdo = getPDO();
+  
+  $stmt = $pdo->prepare('SELECT m.sender_id,
+                                u.username AS sender_username,
+                                m.sender_id = ? AS viewer_is_owner,
+                                m.time,
+                                m.content
+                        FROM group_messages m
+                        LEFT JOIN users u ON m.sender_id = u.id
+                        WHERE m.group_id = ? AND m.time > ?
+                        ORDER BY m.time ASC');
+
+  $stmt->execute([$viewer, $group_id, $time_after]);
+
+  return $stmt->fetchAll();
+}
+
+// Mutations
+
+function storeMessage($viewer, $group_id, $content) {
+  $content = trim($content);
+  if (empty($content)) {
+    return false;
+  }
+
+  $pdo = getPDO();
+
+  $stmt = $pdo->prepare('INSERT INTO group_messages (sender_id, group_id, content)
+                         VALUES (?, ?, ?)');
+
+  $stmt->execute([$viewer, $group_id, $content]);
+
+  return $stmt->rowCount() > 0;
+}
+
+?>

--- a/includes/db_polls.php
+++ b/includes/db_polls.php
@@ -1,0 +1,101 @@
+<?php
+require_once "db.php";
+
+// Queries
+
+function getGroupPolls($group_id) {
+  return _getPollsFull('WHERE p.group_id = ?', [$group_id]);
+}
+
+function getPollsById($poll_id) {
+  return _getPollsFull('WHERE p.poll_id = ?', [$poll_id]);
+}
+
+function _getPollsFull($where = '', $params = []) {
+  $pdo = getPDO();
+
+  $stmt = $pdo->prepare('SELECT p.poll_id,
+                                p.group_id,
+                                p.creator_id,
+                                p.poll_title,
+                                o.option_id,
+                                o.option_title,
+                                v.user_id
+                        FROM polls p
+                        LEFT JOIN poll_options o ON p.poll_id = o.poll_id
+                        LEFT JOIN poll_votes v ON o.option_id = v.option_id
+                        '.$where.'
+                        ORDER BY p.poll_id, o.option_id');
+
+  $stmt->execute($params);
+  $rows = $stmt->fetchAll();
+
+  $polls = [];
+  foreach ($rows as $row) {
+    $poll_id = $row['poll_id'];
+    if (!isset($polls[$poll_id])) {
+      $polls[$poll_id] = array_merge($row, [
+        'vote_count' => 0,
+        'options' => [],
+      ]);
+    }
+
+    $option_id = $row['option_id'] ?? null;
+    if (!isset($polls[$poll_id]['options'][$option_id]) && $option_id !== null) {
+      $polls[$poll_id]['options'][$option_id] = array_merge($row, [
+        'vote_count' => 0,
+        'votes' => [],
+      ]);
+    }
+
+    $user_id = $row['user_id'] ?? null;
+    if ($user_id !== null) {
+      $polls[$poll_id]['vote_count']++;
+      $polls[$poll_id]['options'][$option_id]['vote_count']++;
+      $polls[$poll_id]['options'][$option_id]['votes'][] = $user_id;
+    }
+  }
+
+  return $polls;
+}
+
+
+// Mutations
+
+function createPoll($viewer, $group_id, $title) {
+  $pdo = getPDO();
+
+  $stmt = $pdo->prepare('INSERT IGNORE INTO polls (group_id, creator_id, poll_title) VALUES (?, ?, ?)');
+  $stmt->execute([$group_id, $viewer, $title]);
+  
+  return $pdo->lastInsertId();
+}
+
+function createOption($poll_id, $title) {
+  $pdo = getPDO();
+
+  $stmt = $pdo->prepare('INSERT IGNORE INTO poll_options (poll_id, option_title) VALUES (?, ?)');
+  $stmt->execute([$poll_id, $title]);
+
+  return $pdo->lastInsertId();
+}
+
+function updateVotes($viewer, $poll_id, $options) {
+  $pdo = getPDO();
+  $pdo->beginTransaction();
+
+  $stmt = $pdo->prepare('DELETE v
+                         FROM poll_votes v
+                         JOIN poll_options o ON v.option_id = o.option_id
+                         WHERE o.poll_id = ? AND v.user_id = ?');
+  $stmt->execute([$poll_id, $viewer]);
+
+  foreach ($options as $opt) {
+    $stmt = $pdo->prepare('INSERT INTO poll_votes (option_id, user_id) VALUES (?, ?)');
+    $stmt->execute([$opt, $viewer]);
+  }
+
+  $pdo->commit();
+}
+
+?>

--- a/includes/db_users.php
+++ b/includes/db_users.php
@@ -2,7 +2,7 @@
 
 // Queries
 
-function getUserById($user_id) {
+function getUserById($viewer, $user_id) {
   if ($user_id === null)
   return null;
   
@@ -10,11 +10,13 @@ function getUserById($user_id) {
   $stmt = $pdo->prepare('SELECT u.id,
                                 u.username,
                                 u.email,
-                                e.date AS birthdate
+                                e.date AS birthdate,
+                                fu.favorite_user_id IS NOT NULL as favorite
                         FROM users u
                         JOIN events e ON u.birthday_event = e.event_id
+                        LEFT JOIN favorite_users fu ON fu.user_id = ? AND fu.favorite_user_id = u.id
                         WHERE u.id = ?');
-  $stmt->execute([$user_id]);
+  $stmt->execute([$viewer, $user_id]);
   
   $user = $stmt->fetch();
   

--- a/includes/session.php
+++ b/includes/session.php
@@ -11,7 +11,7 @@ function getUserId() {
   
   if (!$user) {
     startSession();
-    $user = getUserById($_SESSION['user_id'] ?? null);
+    $user = getUserById(null, $_SESSION['user_id'] ?? null);
     if (!$user) {
       return null;
     }

--- a/index.php
+++ b/index.php
@@ -49,12 +49,12 @@ include 'templates/main_header.php'
 ?>
 
 <section class="content">
-  <header>
+  <header class="space-betwen">
     <h1>Events</h1>
     <a class="btn" href="event_create.php">Create Event</a>
   </header>
   <?php if (anyFavorite($events)): ?>
-    <header>
+    <header class="space-betwen">
       <button type="button" class="btn" id="toggle_expand">&nbsp;</button>
     </header>
   <?php endif ?>
@@ -84,7 +84,7 @@ include 'templates/main_header.php'
         <?php foreach ($date_events as $event): ?>
           <li class="event-item <?php echo $event['favorite'] ? "" : "hidden" ?>">
             <span>
-              <?php echo $event['name'] ?>
+              <?php echo htmlspecialchars($event['name']) ?>
               <?php if ($event['creator_id']): ?>
                 <span> • <a href="user.php?id=<?php echo $event['creator_id'] ?>"><?php echo $event['creator_username'] ?></a></span>
               <?php endif ?>

--- a/javascript/chat.js
+++ b/javascript/chat.js
@@ -1,0 +1,118 @@
+/**
+ * 
+ * @param {HTMLFormElement} formEl
+ * @param {HTMLElement} historyEl
+ */
+function chatInit(formEl, historyEl) {
+  const CONTENT_KEY = 'content'
+  const TIME_KEY = 'time_after'
+
+  const contentEl = formEl.elements.namedItem(CONTENT_KEY)
+  let last = null
+
+  async function fetchMessages() {
+    const formData = new FormData(formEl)
+    formData.delete(CONTENT_KEY)
+    formData.append(TIME_KEY, last?.message.time || null)
+    const url = formEl.action+'?'+(new URLSearchParams(formData).toString())
+
+    const lastBefore = last?.message;
+    try {
+      const res = await fetch(url)
+      // If not equal another fetch has been processed
+      // and the result of this fetch should be ignored.
+      if (lastBefore !== last?.message) {
+        return []
+      }
+
+      const messages =  await res.json()
+      return messages
+    } catch(e) {
+      console.error(e)
+      return []
+    }
+  }
+
+  function newSeries(message) {
+    const seriesEl = document.createElement('div')
+    seriesEl.classList.add('message-series')
+    if (message.viewer_is_owner) {
+      seriesEl.classList.add('owner')
+    } else {
+      const nameEl = document.createElement('div')
+      nameEl.className = 'sender-name'
+      nameEl.textContent = message.sender_username
+      seriesEl.appendChild(nameEl)
+    }
+    last = { seriesEl, message }
+    return seriesEl
+  }
+
+  function processMessages(messages) {
+    if (!messages || !messages.length) return
+
+    const senderDifferent = (prev, curr) =>
+      prev.sender_username != curr.sender_username
+    const intervalAbove = (interval, prev, curr) => 
+      (new Date(curr.time).getTime() - new Date(prev.time).getTime()) > interval
+
+    const messagesFragment = document.createDocumentFragment()
+    for (let message of messages) {
+      if (!last || intervalAbove(10 * 60 * 1000, last.message, message)) {
+        const dateEl = document.createElement('div')
+        dateEl.className = 'messages-date'
+        dateEl.textContent = new Date(message.time).toLocaleString('en-UK')
+        messagesFragment.appendChild(dateEl)
+        messagesFragment.appendChild(newSeries(message))
+      }
+      if (!last || senderDifferent(last.message, message)) {
+        messagesFragment.appendChild(newSeries(message))
+      }
+      last.message = message
+
+      const msgEl = document.createElement('div')
+      msgEl.className = 'message'
+      msgEl.textContent = message.content
+
+      last.seriesEl.appendChild(msgEl)
+    }
+
+    historyEl.appendChild(messagesFragment)
+    historyEl.scrollTo(0, historyEl.scrollHeight)
+  }
+
+  async function sendMessage() {
+    if (! contentEl.value.trim()) {
+      return
+    }
+
+    const formData = new FormData(formEl)
+    contentEl.value = ''
+    await fetch(formEl.action, {body: formData, method: 'post'})
+
+    // After fetch immediately
+    processMessages(await fetchMessages())
+  }
+
+  contentEl.addEventListener('keydown', ev => {
+    if (ev.key === 'Enter' && !ev.shiftKey) {
+      ev.preventDefault()
+      sendMessage()
+    }
+  })
+
+  formEl.addEventListener('submit', ev => {
+    ev.preventDefault()
+    sendMessage()
+  })
+
+  async function monitorMessages() {
+    while (true) {
+      processMessages(await fetchMessages())
+      // Fallback if server side polling is disabled
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  }
+
+  monitorMessages()
+}

--- a/javascript/event_view.js
+++ b/javascript/event_view.js
@@ -1,0 +1,9 @@
+function toggleModifyForm() {
+  const form = document.getElementById('modifyForm');
+  form.style.display = form.style.display === 'none' ? 'block' : 'none';
+}
+
+function toggleDeleteModal() {
+  const modal = document.getElementById('deleteModal');
+  modal.style.display = modal.style.display === 'none' ? 'block' : 'none';
+}

--- a/javascript/group_edit.js
+++ b/javascript/group_edit.js
@@ -1,96 +1,14 @@
-// Preserve last open Panel on page reload
-(function () {
-  panel_name = localStorage.getItem('last-panel');
-  console.log(panel_name)
-  
-  switch (panel_name) {
-    case 'group-edit-panel':
-      changeToEditGroupPanel();
-      break;
-    
-    case 'group-members-panel':
-      changeToGroupMembersPanel();
-      break;
-    
-    case 'group-add-panel':
-      changeToAddMembersPanel();
-      break;
-  };
-})();
+(function(){
+  const STORAGE_KEY = 'last-panel'
+  const KEYS = ['group-edit', 'group-members', 'group-add']
+  const swicthToPanel = tabs_init({keys: KEYS, onClick: (key) => {
+    localStorage.setItem(STORAGE_KEY, key)}
+  })
 
-// Hide/Show Edit Group Panel
-function toggleEditGroupPanel(value) {
-  const panel = document.getElementById('group-edit-panel');
-  const btn = document.getElementById('btn-toggle-edit');
-
-  if (value === 'on') { // show
-    localStorage.setItem('last-panel', 'group-edit-panel');
-
-    btn.classList.remove('inactive');
-    panel.style.display = 'block';
-  }
-
-  if (value === 'off') {// hide
-    btn.classList.add('inactive');
-    panel.style.display = 'none';
-  }
-}
-
-// Hide/Show Group Members Panel
-function toggleGroupMembersPanel(value) {
-  const panel = document.getElementById('group-members-panel');
-  const btn = document.getElementById('btn-toggle-members');
-
-  if (value === 'on') { // show
-    localStorage.setItem('last-panel', 'group-members-panel');
-
-    btn.classList.remove('inactive');
-    panel.style.display = 'block';
-  }
-
-  if (value === 'off') {// hide
-    btn.classList.add('inactive');
-    panel.style.display = 'none';
-  }
-}
-
-// Hide/Show Add Members Panel
-function toggleAddMembersPanel(value) {
-  const panel = document.getElementById('group-add-panel');
-  const btn = document.getElementById('btn-toggle-add');
-
-  if (value === 'on') { // show
-    localStorage.setItem('last-panel', 'group-add-panel');
-
-    btn.classList.remove('inactive');
-    panel.style.display = 'block';
-  }
-
-  if (value === 'off') {// hide
-    btn.classList.add('inactive');
-    panel.style.display = 'none';
-  }
-}
-
-// Shows 'Edit Group' and Hides 'Group Members' Panel
-function changeToEditGroupPanel() {
-  toggleEditGroupPanel('on');
-  toggleGroupMembersPanel('off');
-  toggleAddMembersPanel('off');
-}
-
-// Shows 'Edit Group' and Hides 'Group Members' Panel
-function changeToGroupMembersPanel() {
-  toggleEditGroupPanel('off');
-  toggleGroupMembersPanel('on');
-  toggleAddMembersPanel('off');
-}
-
-function changeToAddMembersPanel() {
-  toggleEditGroupPanel('off');
-  toggleGroupMembersPanel('off');
-  toggleAddMembersPanel('on');
-}
+  // Preserve last open Panel on page reload
+  const lastPanel = localStorage.getItem(STORAGE_KEY) || PANEL_KEYS[0]
+  swicthToPanel(lastPanel)
+})()
 
 
 // Show/Hide element with given name

--- a/javascript/group_view.js
+++ b/javascript/group_view.js
@@ -1,0 +1,19 @@
+(function() {
+  const KEYS = ['chat', 'polls']
+  const switchPanel = tabs_init({keys: KEYS, onClick: (key) => (location.hash = key, true) })
+  const cleanHash = (hash) => hash.replace('#', '')
+  window.addEventListener('hashchange', () => switchPanel(cleanHash(location.hash)))
+  switchPanel(cleanHash(location.hash) || KEYS[0])
+
+  const chatForm = document.getElementById('chat-form')
+  const chatHistory = document.getElementById('chat-history')
+  if (chatForm && chatHistory) {
+    chatInit(chatForm, chatHistory)
+  }
+
+  const pollsForms = document.querySelectorAll('form.poll-form:not(.create)')
+  const pollCreateForm = document.querySelector('form.poll-form.create')
+  if (pollsForms && pollCreateForm) {
+    pollsInit(pollsForms, pollCreateForm);
+  }
+})()

--- a/javascript/polls.js
+++ b/javascript/polls.js
@@ -1,0 +1,55 @@
+/**
+ * 
+ * @param {NodeListOf<HTMLFormElement>} existingForms
+ * @param {HTMLFormElement} createForm 
+ */
+function pollsInit(existingForms, createForm) {
+  /**
+   * @param {HTMLFormElement} form
+   * @param {HTMLElement?} submitter */
+  async function getUpdatedForm(form, submitter) {
+    const formData = new FormData(form);
+    if (submitter) {
+      formData.append(submitter.name, submitter.value)
+    }
+    const html = await (await fetch(form.action, {method: form.method, body: formData})).text()
+    const t = document.createElement('template')
+    t.innerHTML = html
+    return t.content.children[0]
+  }
+
+  /**
+   * @param {HTMLFormElement} form
+   * @param {HTMLElement} submitter */
+  async function updateForm(form, submitter) {
+    const newForm = await getUpdatedForm(form, submitter)
+    monitorForm(newForm)
+    form.replaceWith(newForm)
+  }
+
+  /**
+   * @param {HTMLFormElement} form */
+  function monitorForm(form) {
+    form.addEventListener('change', ev => {
+      if (ev.target.type === 'checkbox') {
+        updateForm(form)
+      }
+    })
+    form.addEventListener('submit', ev => {
+      ev.preventDefault()
+      updateForm(form, ev.submitter)
+    })
+  }
+
+  existingForms.forEach(monitorForm)
+
+  createForm.addEventListener('submit', async ev => {
+    ev.preventDefault()
+
+    const newForm = await getUpdatedForm(createForm)
+    createForm.reset()
+
+    monitorForm(newForm)
+    createForm.insertAdjacentElement('beforebegin', newForm)
+  })
+}

--- a/javascript/tabs.js
+++ b/javascript/tabs.js
@@ -1,0 +1,39 @@
+function tabs_init(options) {
+  options = Object.assign({}, {
+    keys: null,
+    panelSuffix: '-panel',
+    btnSuffix: '-toggle',
+    activeClass: 'active',
+    inactiveClass: 'inactive',
+    onClick: () => {},
+  }, options)
+
+  if (!options.keys) return;
+
+  function switchTo(targetKey) {
+    for (const key of options.keys) {
+      const btn = document.getElementById(key+options.btnSuffix)
+      const panel = document.getElementById(key+options.panelSuffix)
+      if (targetKey === key) {
+        panel.style.display = 'revert'
+        btn.classList.add(options.activeClass)
+        btn.classList.remove(options.inactiveClass)
+      } else {
+        panel.style.display = 'none'
+        btn.classList.remove(options.activeClass)
+        btn.classList.add(options.inactiveClass)
+      }
+    }
+  }
+
+  for (const key of options.keys) {
+    const btn = document.getElementById(key+options.btnSuffix)
+    btn.addEventListener('click', () => {
+      if (!options.onClick(key)) {
+        switchTo(key)
+      }
+    })
+  }
+
+  return switchTo
+}

--- a/login.php
+++ b/login.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $error_messages[] = 'Invalid username or password!';
   } else {
     $_SESSION['user_id'] = $userId;
-    header('Location: login.php');
+    header('Location: ./');
     exit;
   }
 }

--- a/mysql/create.sql
+++ b/mysql/create.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Host: 127.0.0.1
--- Generation Time: Jan 25, 2025 at 09:05 AM
+-- Generation Time: Jan 27, 2025 at 03:37 PM
 -- Server version: 10.4.32-MariaDB
 -- PHP Version: 8.2.12
 
@@ -83,6 +83,59 @@ DROP TABLE IF EXISTS `favorite_users`;
 CREATE TABLE `favorite_users` (
   `user_id` int(11) NOT NULL,
   `favorite_user_id` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `group_messages`
+--
+
+DROP TABLE IF EXISTS `group_messages`;
+CREATE TABLE `group_messages` (
+  `group_id` int(11) NOT NULL,
+  `sender_id` int(11) NOT NULL,
+  `time` datetime(3) NOT NULL DEFAULT current_timestamp(3),
+  `content` varchar(1000) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `polls`
+--
+
+DROP TABLE IF EXISTS `polls`;
+CREATE TABLE `polls` (
+  `poll_id` int(11) NOT NULL,
+  `group_id` int(11) NOT NULL,
+  `creator_id` int(11) NOT NULL,
+  `poll_title` varchar(100) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `poll_options`
+--
+
+DROP TABLE IF EXISTS `poll_options`;
+CREATE TABLE `poll_options` (
+  `option_id` int(11) NOT NULL,
+  `poll_id` int(11) NOT NULL,
+  `option_title` varchar(100) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `poll_votes`
+--
+
+DROP TABLE IF EXISTS `poll_votes`;
+CREATE TABLE `poll_votes` (
+  `option_id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
@@ -170,6 +223,36 @@ ALTER TABLE `favorite_users`
   ADD KEY `favorite_user_id` (`favorite_user_id`);
 
 --
+-- Indexes for table `group_messages`
+--
+ALTER TABLE `group_messages`
+  ADD KEY `group_id` (`group_id`),
+  ADD KEY `sender_id` (`sender_id`),
+  ADD KEY `time` (`time`);
+
+--
+-- Indexes for table `polls`
+--
+ALTER TABLE `polls`
+  ADD PRIMARY KEY (`poll_id`),
+  ADD UNIQUE KEY `group_id` (`group_id`,`poll_title`),
+  ADD KEY `creator_id` (`creator_id`);
+
+--
+-- Indexes for table `poll_options`
+--
+ALTER TABLE `poll_options`
+  ADD PRIMARY KEY (`option_id`),
+  ADD UNIQUE KEY `poll_id` (`poll_id`,`option_title`);
+
+--
+-- Indexes for table `poll_votes`
+--
+ALTER TABLE `poll_votes`
+  ADD PRIMARY KEY (`option_id`,`user_id`),
+  ADD KEY `user_id` (`user_id`);
+
+--
 -- Indexes for table `users`
 --
 ALTER TABLE `users`
@@ -218,6 +301,18 @@ ALTER TABLE `event_groups`
   MODIFY `group_id` int(11) NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT for table `polls`
+--
+ALTER TABLE `polls`
+  MODIFY `poll_id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `poll_options`
+--
+ALTER TABLE `poll_options`
+  MODIFY `option_id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `users`
 --
 ALTER TABLE `users`
@@ -252,6 +347,33 @@ ALTER TABLE `event_to_group`
 ALTER TABLE `favorite_users`
   ADD CONSTRAINT `favorite_users_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   ADD CONSTRAINT `favorite_users_ibfk_2` FOREIGN KEY (`favorite_user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `group_messages`
+--
+ALTER TABLE `group_messages`
+  ADD CONSTRAINT `group_messages_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `event_groups` (`group_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `group_messages_ibfk_2` FOREIGN KEY (`sender_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `polls`
+--
+ALTER TABLE `polls`
+  ADD CONSTRAINT `polls_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `event_groups` (`group_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `polls_ibfk_2` FOREIGN KEY (`creator_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `poll_options`
+--
+ALTER TABLE `poll_options`
+  ADD CONSTRAINT `poll_options_ibfk_1` FOREIGN KEY (`poll_id`) REFERENCES `polls` (`poll_id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `poll_votes`
+--
+ALTER TABLE `poll_votes`
+  ADD CONSTRAINT `poll_votes_ibfk_1` FOREIGN KEY (`option_id`) REFERENCES `poll_options` (`option_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `poll_votes_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
 -- Constraints for table `users`

--- a/poll.php
+++ b/poll.php
@@ -1,0 +1,27 @@
+<?php
+require_once 'includes/session.php';
+require_once 'includes/db_polls.php';
+
+ensureLoggedIn();
+
+$poll_id = $_GET['poll_id'] ?? $_POST['poll_id'] ?? null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (isset($_POST['poll_create'])) {
+    $poll_id = createPoll($user['id'], $_POST['group_id'], $_POST['poll_title']);
+  } else {
+    if (!$poll_id) exit;
+
+    if (isset($_POST['option_add'])) {
+      createOption($poll_id, $_POST['option_title'] ?? '');
+    } else {
+      updateVotes($user['id'], $poll_id, $_POST['options'] ?? []);
+    }
+  }
+}
+
+if (!$poll_id) exit;
+$polls = getPollsById($poll_id);
+?>
+
+<?php include 'templates/polls_template.php' ?>

--- a/profile.php
+++ b/profile.php
@@ -8,7 +8,7 @@ ensureLoggedIn();
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   updateUser($user['id'], $_POST['username'], $_POST['email'], $_POST['birthdate']);
 
-  header('Refresh: 0');
+  header('Location: '.$_SERVER['REQUEST_URI']);
   exit;
 }
 ?>

--- a/styles/groups.css
+++ b/styles/groups.css
@@ -73,3 +73,161 @@ ul.group-list li {
 #input-group-pass {
   max-width: 150px;
 }
+
+ul.group-tabs {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 1em;
+}
+
+ul.group-tabs li {
+  padding: 1em;
+  flex: 1 1 auto;
+  text-align: center;
+  border: 1px solid #aaa;
+  border-radius: 1em 1em 0 0;
+  cursor: pointer;
+}
+
+ul.group-tabs li.active {
+  border-bottom: none;
+  font-weight: bold;
+}
+
+ul.group-tabs li:not(.active) {
+  border-top: none;
+  border-left: none;
+  border-right: none;
+}
+
+.chat {
+  padding: 1em;
+}
+
+.chat-history {
+  height: 30em;
+  overflow-y: auto;
+}
+
+.message-series {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  margin: 1em 0;
+}
+
+.message-series .message {
+  max-width: 80%;
+  padding: 1em;
+  margin: 0.1em 0;
+  border-radius: 1em;
+  color: var(--color-text);
+  background-color: var(--color-background-body);
+}
+
+.message-series.owner {
+  align-items: end;
+}
+
+.message-series.owner .message {
+  color: var(--color-text-accent);
+  background-color: var(--color-chat-bubble);
+}
+
+.message-series .sender-name {
+  color: #888;
+  margin: 0 1em;
+}
+
+.messages-date {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #888;
+}
+
+.chat-form {
+  display: flex;
+  gap: 0.5em;
+}
+
+.chat-form textarea {
+  resize: none;
+  flex: 1 1 auto;
+  margin: 1em 0;
+}
+
+.chat-form button {
+  width: 3em;
+  height: 3em;
+  margin: 2em 0;
+  color: var(--color-text-accent);
+  background-color: var(--color-chat-bubble);
+  border: none;
+  border-radius: 50%;
+}
+
+.polls {
+  padding: 1em;
+  display: flex;
+}
+
+.polls-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  background-color: var(--color-background-body);
+  padding: 1em
+}
+
+.poll-form {
+  background: var(--color-background);
+  padding: 1em 2em;
+}
+
+.poll-form.create {
+  margin-top: 2em;
+}
+
+.poll-form label {
+  display: flex;
+  flex-direction: column;
+  margin: 1em 0;
+}
+
+.poll-form .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+}
+
+.poll-form .row input[type=checkbox] {
+  margin: 0 1em 0 0;
+}
+
+.poll-form meter,
+.poll-form input[type=text] {
+  flex: 1 1 auto;
+}
+
+.poll-form meter::-webkit-meter-optimum-value {
+  background: var(--color-chat-bubble);
+}
+
+.poll-form input[type=text] {
+  margin: 0;
+  padding: 0.5em;
+  border: none;
+  border-bottom: 1px solid;
+  border-radius: 0;
+}
+
+.poll-form .btn {
+  width: 100%;
+}
+
+.poll-form .add-option {
+  border: none;
+  padding: 0.5em 1em;
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -6,10 +6,11 @@
   --color-background-body: #eee;
   --color-text: #000;
   --color-text-accent: #fff;
-  --color-text-error: #f00;
-  --color-text-error-active: #e60000;
-  --color-text-confirm: #0f0;
-  --color-text-confirm-active: #00e600;
+  --color-text-error: #dc3545;
+  --color-text-error-active: #c82333;
+  --color-text-confirm: #28a745;
+  --color-text-confirm-active: #218838;
+  --color-chat-bubble: #1f8aff;
   --nav-height: 3.5em;
 }
 
@@ -85,6 +86,7 @@ label {
   background-color: var(--color-accent);
   text-align: center;
   align-content: center;
+  white-space: nowrap;
 }
 
 .btn:hover {
@@ -214,10 +216,11 @@ body > nav .profile-picture {
   height: 70%;
 }
 
-header {
+header.space-betwen {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1em
 }
 
 .content {
@@ -319,6 +322,10 @@ ul.event-list li {
 
 ul.date-list.hide .hidden {
   display: none;
+}
+
+ul.user-owned li {
+  margin: 1em 0;
 }
 
 /* Large screens only */

--- a/templates/polls_template.php
+++ b/templates/polls_template.php
@@ -1,0 +1,25 @@
+<?php foreach ($polls as $poll): ?>
+<form method="POST" action="poll.php" class="poll-form">
+  <input type="hidden" name="poll_id" value="<?php echo $poll['poll_id'] ?>">
+  <h3><?php echo htmlspecialchars($poll['poll_title']) ?></h3>
+  <?php foreach ($poll['options'] as $opt): ?>
+  <label>
+    <div class="row">
+      <span>
+        <?php $checked = in_array($user['id'], $opt['votes']) ? "checked" : "" ?>
+        <input type="checkbox" name="options[]" value="<?php echo $opt['option_id'] ?>" <?php echo $checked ?>>
+        <?php echo htmlspecialchars($opt['option_title']) ?>
+      </span>
+      <span><?php echo $opt['vote_count'].'/'.$poll['vote_count'] ?></span>
+    </div>
+    <div class="row">
+      <meter max="<?php echo $poll['vote_count'] ?>" value="<?php echo $opt['vote_count'] ?>"></meter>
+    </div>
+  </label>
+  <?php endforeach ?>
+  <div class="row">
+    <button type="submit" name="option_add" class="add-option">+</button>
+    <input type="text" name="option_title" placeholder="Add Option" required>
+  </div>
+</form>
+<?php endforeach ?>

--- a/templates/user_favorite.php
+++ b/templates/user_favorite.php
@@ -1,0 +1,9 @@
+<?php function favorite_user_form($user_id, $value, $enabled = true) { ?>
+  <?php if ($enabled): ?>
+  <form method="POST">
+    <input type="hidden" name="user_id" value="<?php echo $user_id ?>">
+    <input type="hidden" name="favorite" value="<?php echo !($value) ?>">
+    <button type="submit" class="btn-favorite"><?php echo $value ? '★' : '☆' ?></button>
+  </form>
+  <?php endif ?>
+<?php } ?>

--- a/user.php
+++ b/user.php
@@ -3,20 +3,32 @@ require_once 'includes/config.php';
 require_once 'includes/session.php';
 require_once 'includes/db_users.php';
 require_once 'includes/db_events.php';
+require_once 'includes/db_groups.php';
 
 ensureLoggedIn();
 
-if (!isset($_GET['id'])) {
-  http_response_code(404);
-  die;
+$profile = getUserById($user['id'], $_GET['id']);
+if (!$profile) {
+  header('Location: users.php');
+  exit;
 }
 
-$profile = getUserById($_GET['id']);
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (isset($_POST['favorite'])) {
+    userFavorite($user['id'], $_POST['user_id'], $_POST['favorite']);
+  }
+
+  header('Location: '.$_SERVER['REQUEST_URI']);
+  exit;
+}
+
 $events = getEventsByOwner($user['id'], $profile['id']);
+$groups = getGroupsByOwner($user['id'], $profile['id']);
 ?>
 
 <?php
 $page_title = "User Profile";
+include 'templates/user_favorite.php';
 include 'templates/main_header.php';
 ?>
 
@@ -25,21 +37,36 @@ include 'templates/main_header.php';
     <section class="profile-info">
       <img class="profile-picture" alt="Profile Picture" src="<?php echo gravatarUrl($profile) ?>">
       <h1><?php echo $profile['username'] ?>'s profile</h1>
+      <?php favorite_user_form($profile['id'], $profile['favorite'], $user['id'] !== $profile['id']) ?>
     </section>
     <p><strong>Birthday:</strong> <?php echo $profile['birthdate'] ?></p>
     <hr>
-    <h2><?php echo $profile['username'] ?>'s events</h2>
-    <ul>
+
+    <h2>Events</h2>
+    <ul class="user-owned">
     <?php foreach ($events as $event): ?>
       <li>
         <a href="<?php echo "event_view.php?event_id=".$event['event_id']."&year=".date('Y') ?>">
-          <?php echo $event['name'] ?> |
+          <?php echo htmlspecialchars($event['name']) ?> |
           <?php echo $event['date'] ?> |
           <?php echo $event['recurring'] ? "Recurring" : "Non Recurring" ?>
         </a>
       </li>
     <?php endforeach ?>
     </ul>
+
+    <h2>Groups</h2>
+    <ul class="user-owned">
+    <?php foreach ($groups as $group): ?>
+      <li>
+        <a href="<?php echo "group_view.php?group_id=".$group['group_id'] ?>">
+          <?php echo $group['event_name'] ?> /
+          <?php echo $group['group_name'] ?>
+        </a>
+      </li>
+    <?php endforeach ?>
+    </ul>
+
   </section>
 </section>
 

--- a/users.php
+++ b/users.php
@@ -10,7 +10,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     userFavorite($user['id'], $_POST['user_id'], $_POST['favorite']);
   }
 
-  header('Refresh: 0');
+  header('Location: '.$_SERVER['REQUEST_URI']);
   exit;
 }
 
@@ -19,12 +19,13 @@ $query = $_GET['q'] ?? ""
 
 <?php
 $page_title = "Users";
+include 'templates/user_favorite.php';
 include 'templates/main_header.php';
 include 'templates/data_table.php'
 ?>
 
 <section class="content">
-  <header>
+  <header class="space-betwen">
     <h1>Users</h1>
     <form class="form-filter" method="GET">
       <input type="text" name="q" value="<?php echo $query ?>" placeholder="Filter..." autofocus>
@@ -38,13 +39,7 @@ include 'templates/data_table.php'
              [
               "Favorite" => function($row) {
                 global $user;
-                ?><form method="POST">
-                  <input type="hidden" name="user_id" value="<?php echo $row['id'] ?>">
-                  <input type="hidden" name="favorite" value="<?php echo !($row['favorite']) ?>">
-                  <?php if ($user['id'] !== $row['id']): ?>
-                  <button type="submit" class="btn-favorite"><?php echo $row['favorite'] ? '★' : '☆' ?></button>
-                  <?php endif ?>
-                </form><?php
+                favorite_user_form($row['id'], $row['favorite'], $user['id'] !== $row['id']);
               },
               "User" => function($row) {
                 ?><a href="<?php echo "user.php?id=".$row['id'] ?>">


### PR DESCRIPTION
NEW:
- Added real time chat to the group page
  - Using "HTTP Long Polling" as WebSockets implementation is out of scope
  - Automatically configured to wait up to 80% of max_execution_time
  - Fallback to normal client side polling if required
- Added group polls
  - Very basic implementation - only create, add option, and vote
- Added all group info to the view pages such as time, location, etc
- Added User's groups to their profile
- Added Favorite button to the profile
  - Extracted common favorite template

Changes:
- Added `htmlspecialchars` where echoing raw user input to prevent js injection
- Group leave - Done in a single transaction to avoid leaving db in bad state on fail
  - Fix leaving a private group makes it public due to loss of password.
- Extract common tabs.js for group_edit and group_view
- Page reloads done with `Refresh: 0` appear slow and flash the screen
  - Every reload replaced with `Location: $_SERVER['REQUEST_URI']`
  - Missing reloads after POST have been added (if not specified the browser may ask for secondary form submit)
- Clean up query parameters - group can be identified by id only.
  - We cannot trust the client to send correct event and year.
- Add not found checks for most pages - when deleted from db or wrong url.

DB Changes:
- Added tables for chat and polls

Preview:
![image](https://github.com/user-attachments/assets/2acf2d75-2e72-4e27-9137-f26a68837f02)
![image](https://github.com/user-attachments/assets/66f5b50c-b709-45b1-8142-fb62fa181c8c)
